### PR TITLE
fixes issue #8: getting rid of race condition and watchdog timer restarts

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -15,6 +15,7 @@ void processing_task(void *param)
   while (true)
   {
     application->process_samples();
+    vTaskDelay(1);
   }
 }
 
@@ -34,12 +35,12 @@ Application::Application(TFT_eSPI &display)
 
 void Application::begin()
 {
+  // start sampling from i2s device
+  m_sampler->start();
   // set up the processing
   TaskHandle_t processing_task_handle;
   xTaskCreatePinnedToCore(processing_task, "Processing Task", 4096, this, 2, &processing_task_handle, 0);
 
-  // start sampling from i2s device
-  m_sampler->start();
 }
 
 void Application::process_samples()


### PR DESCRIPTION
PR fixes two issues:
1. Sketch core-dumps in infinite loop on the first m_sampler->read(m_sample_buffer, WINDOW_SIZE) call with the output, provided in the #8 
2. After fixing the first item, sketch is running, but from time to time is aborts and restarts with 
E (30476) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time (see full output in the #8)
This happens because all the tasks runs infinitely, but FreeRTOS wants at least some yeld for its housekeeping.
Fix is to add vTaskDelay(1); inside the loop in the processing_task function